### PR TITLE
added option to keep subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,6 @@ pip-log.txt
 
 # Comics
 *.cbz
+temp_merge
+temp_merge/*
+temp_merge/**/*

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,8 @@ Desktop.ini
 #############
 
 *.py[co]
+__pycache__
+__pycache__/*
 
 # Packages
 *.egg
@@ -161,3 +163,6 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+# Comics
+*.cbz

--- a/ComicMerge.py
+++ b/ComicMerge.py
@@ -2,130 +2,131 @@ import os
 import shutil
 import zipfile
 
-
 class ComicMerge:
-    def __init__(self, output_name, comics_to_merge, is_verbose=True):
-        self.output_name = output_name
-        if not self.output_name.endswith(".cbz"):
-            self.output_name = self.output_name + ".cbz"
-        self.comics_to_merge = comics_to_merge
-        self.is_verbose = is_verbose
+	def __init__(self, output_name, comics_to_merge, is_verbose=True):
+		self.output_name = output_name
+		if not self.output_name.endswith(".cbz"):
+			self.output_name = self.output_name + ".cbz"
+		self.comics_to_merge = comics_to_merge
+		self.is_verbose = is_verbose
 
-    def _log(self, msg):
-        self._log_static(msg, self.is_verbose)
+	def _log(self, msg):
+		self._log_static(msg, self.is_verbose)
 
-    @staticmethod
-    def _log_static(msg, verbose):
-        if verbose:
-            print(msg)
+	@staticmethod
+	def _log_static(msg, verbose):
+		if verbose:
+			print(msg)
 
-    @staticmethod
-    def _extract_cbz(file_name, destination, verbose):
-        output_dir = os.path.join(destination, os.path.splitext(file_name)[0])
-        os.mkdir(output_dir)
-        ComicMerge._log_static('Unzipping ' + file_name, verbose)
-        zip_file = zipfile.ZipFile(file_name)
-        zip_file.extractall(output_dir)
-        zip_file.close()
+	@staticmethod
+	def _extract_cbz(file_name, destination, verbose):
+		output_dir = os.path.join(destination, os.path.splitext(file_name)[0])
+		os.mkdir(output_dir)
+		ComicMerge._log_static('Unzipping ' + file_name, verbose)
+		zip_file = zipfile.ZipFile(file_name)
+		zip_file.extractall(output_dir)
+		zip_file.close()
 
-    @staticmethod
-    def _remove_file(file_name):
-        if os.path.exists(file_name):
-            os.remove(file_name)
+	@staticmethod
+	def _remove_file(file_name):
+		if os.path.exists(file_name):
+			os.remove(file_name)
 
-    @staticmethod
-    def _find_temp_folder():
-        base_dir = 'temp_merge'
-        mod = 0
-        temp_dir = base_dir
-        while os.path.exists(temp_dir):
-            mod += 1
-            temp_dir = base_dir + str(mod)
-        return temp_dir
+	@staticmethod
+	def _find_temp_folder():
+		base_dir = 'temp_merge'
+		mod = 0
+		temp_dir = base_dir
+		while os.path.exists(temp_dir):
+			mod += 1
+			temp_dir = base_dir + str(mod)
+		return temp_dir
 
-    @staticmethod
-    def _extract_comics(comics_to_extract, temp_dir, verbose):
-        for file_name in comics_to_extract:
-            ComicMerge._extract_cbz(file_name, temp_dir, verbose)
+	@staticmethod
+	def _extract_comics(comics_to_extract, temp_dir, verbose):
+		for file_name in comics_to_extract:
+			ComicMerge._extract_cbz(file_name, temp_dir, verbose)
 
-        # Flatten file structure (subdirectories mess with some readers)
-        files_moved = 1
-        for path_to_dir, subdir_names, file_names in os.walk(temp_dir, False):
-            for file_name in file_names:
-                file_path = os.path.join(path_to_dir, file_name)
-                ext = os.path.splitext(file_name)[1]
-                new_name = 'P' + str(files_moved).rjust(5, '0') + ext
-                ComicMerge._log_static('Renaming & moving ' + file_name + ' to ' + new_name, verbose)
-                shutil.copy(file_path, os.path.join(temp_dir, new_name))
-                files_moved += 1
+		os.system("pause")
 
-            # Deletes all subdirectories (in the end we want a flat structure)
-            # This will not affect walking through the rest of the directories,
-            # because it is traversed from the bottom up instead of top down
-            for subdir_name in subdir_names:
-                shutil.rmtree(os.path.join(path_to_dir, subdir_name))
+		# Flatten file structure (subdirectories mess with some readers)
+		files_moved = 1
+		for path_to_dir, subdir_names, file_names in os.walk(temp_dir, False):
+			for file_name in file_names:
+				file_path = os.path.join(path_to_dir, file_name)
+				ext = os.path.splitext(file_name)[1]
+				new_name = 'P' + str(files_moved).rjust(5, '0') + ext
+				ComicMerge._log_static('Renaming & moving ' + file_name + ' to ' + new_name, verbose)
+				shutil.copy(file_path, os.path.join(temp_dir, new_name))
+				files_moved += 1
 
-    def _make_cbz_from_dir(self, temp_dir):
-        self._log('Initializing cbz ' + self.output_name)
+			# Deletes all subdirectories (in the end we want a flat structure)
+			# This will not affect walking through the rest of the directories,
+			# because it is traversed from the bottom up instead of top down
+			for subdir_name in subdir_names:
+				shutil.rmtree(os.path.join(path_to_dir, subdir_name))
 
-        zip_file = zipfile.ZipFile(self.output_name, 'w', zipfile.ZIP_DEFLATED)
-        self._log('Adding files to cbz ' + self.output_name)
-        add_count = 0
-        for path_to_dir, subdir_names, file_names in os.walk(temp_dir):
-            for file_name in file_names:
-                file_path = os.path.join(path_to_dir, file_name)
-                zip_file.write(file_path, os.path.split(file_path)[1])
-                add_count += 1
-                if add_count % 10 == 0:
-                    self._log(str(add_count) + ' files added.')
+	def _make_cbz_from_dir(self, temp_dir):
+		self._log('Initializing cbz ' + self.output_name)
 
-    @staticmethod
-    # Passing in a start_idx of <= 0 will cause it to start at the beginning of the folder
-    # Passing in an end_idx of < 0 will cause it to end at the end of the folder
-    # Both start_idx and end_idx are inclusive
-    # Index count starts at 1
-    def comics_from_indices(start_idx, end_idx):
-        all_comics = ComicMerge.comics_in_folder()
-        comics = []
-        comic_idx = 1
-        for file_name in all_comics:
-            if start_idx <= comic_idx and (comic_idx <= end_idx or end_idx < 0):
-                comics.append(file_name)
-            comic_idx += 1
-        return comics
+		zip_file = zipfile.ZipFile(self.output_name, 'w', zipfile.ZIP_DEFLATED)
+		self._log('Adding files to cbz ' + self.output_name)
+		add_count = 0
+		for path_to_dir, subdir_names, file_names in os.walk(temp_dir):
+			for file_name in file_names:
+				file_path = os.path.join(path_to_dir, file_name)
+				zip_file.write(file_path, os.path.split(file_path)[1])
+				add_count += 1
+				if add_count % 10 == 0:
+					self._log(str(add_count) + ' files added.')
 
-    @staticmethod
-    def comics_from_prefix(prefix):
-        all_comics = ComicMerge.comics_in_folder()
-        comics = []
-        for file_name in all_comics:
-            if file_name.startswith(prefix):
-                comics.append(file_name)
-        return comics
+	@staticmethod
+	# Passing in a start_idx of <= 0 will cause it to start at the beginning of the folder
+	# Passing in an end_idx of < 0 will cause it to end at the end of the folder
+	# Both start_idx and end_idx are inclusive
+	# Index count starts at 1
+	def comics_from_indices(start_idx, end_idx):
+		all_comics = ComicMerge.comics_in_folder()
+		comics = []
+		comic_idx = 1
+		for file_name in all_comics:
+			if start_idx <= comic_idx and (comic_idx <= end_idx or end_idx < 0):
+				comics.append(file_name)
+			comic_idx += 1
+		return comics
 
-    @staticmethod
-    def comics_in_folder():
-        comics = []
-        for file_name in os.listdir('.'):  # We're not traversing subdirectories because that's a boondoggle
-            if os.path.splitext(file_name)[1] == '.cbz':
-                comics.append(file_name)
-        return comics
+	@staticmethod
+	def comics_from_prefix(prefix):
+		all_comics = ComicMerge.comics_in_folder()
+		comics = []
+		for file_name in all_comics:
+			if file_name.startswith(prefix):
+				comics.append(file_name)
+		return comics
 
-    def merge(self):
-        # Remove existing file, if any (we're going to overwrite it anyway)
-        self._remove_file(self.output_name)
+	@staticmethod
+	def comics_in_folder():
+		comics = []
+		for file_name in os.listdir('.'):  # We're not traversing subdirectories because that's a boondoggle
+			if os.path.splitext(file_name)[1] == '.cbz':
+				comics.append(file_name)
+		return comics
 
-        self._log('Merging comics ' + str(self.comics_to_merge) + ' into file ' + self.output_name)
+	def merge(self):
+		# Remove existing file, if any (we're going to overwrite it anyway)
+		self._remove_file(self.output_name)
 
-        # Find and create temporary directory
-        # (we don't want to use a static one, no need to mess with something extant)
-        temp_dir = self._find_temp_folder()
-        os.mkdir(temp_dir)
+		self._log('Merging comics ' + str(self.comics_to_merge) + ' into file ' + self.output_name)
 
-        self._extract_comics(self.comics_to_merge, temp_dir, self.is_verbose)
-        self._make_cbz_from_dir(temp_dir)
+		# Find and create temporary directory
+		# (we don't want to use a static one, no need to mess with something extant)
+		temp_dir = self._find_temp_folder()
+		os.mkdir(temp_dir)
 
-        # Clean up temporary folder
-        shutil.rmtree(temp_dir)
-        self._log('')
-        print('Successfully merged comics into ' + self.output_name + '!')
+		self._extract_comics(self.comics_to_merge, temp_dir, self.is_verbose)
+		self._make_cbz_from_dir(temp_dir)
+
+		# Clean up temporary folder
+		shutil.rmtree(temp_dir)
+		self._log('')
+		print('Successfully merged comics into ' + self.output_name + '!')

--- a/README.md
+++ b/README.md
@@ -6,38 +6,39 @@ This is a simple tool that allows you to merge multiple .cbz files into a single
 
 ## Usage
 ```
-usage: python comicmerge_cmd.py [-h] [-v] [-p PREFIX] [-r start end] OUTPUT_FILE
+usage: ComicMerge [-h] [-v] [-p PREFIX] [-r start end] [-f] OUTPUT_FILE
 
 Merge multiple cbz files into one.
 
 positional arguments:
-	OUTPUT_FILE           Name of the .cbz file to be created
+  OUTPUT_FILE       Name of the .cbz file to be created. Will automatically append .cbz if necessary.
 
-optional arguments:
-	-h, --help            show this help message and exit
-	-v, --verbose         More information as to the merging progress
-	-p PREFIX, --prefix PREFIX
-						Prefix to restrict comics to
-	-r start end, --range start end
-						Specified by the format X Y. Only the Xth to Yth comic
-						in the folder will be merged into the output file.
-						Counting starts at 1. The range is inclusive.
+options:
+  -h, --help        show this help message and exit
+  -v, --verbose     More information as to the merging progress
+  -p PREFIX, --prefix PREFIX
+                    Prefix to restrict comics to
+  -r start end, --range start end
+                    Specified by the format X Y. Only the Xth to Yth comic in the folder will be merged into the output file.
+  -f, --folders     Don't flatten the directory tree, keep subfolders
 ```
-
-This script will probably work on Linux, Mac, and Windows, but it has only been tested on Windows.
-
 ## Features of this fork
 - also works without providing either range or prefix (merges all comics in folder)
+- `-f`/`--folders` flag, outputs a cbz with internally separated chapters by folders
+- proper information about merging progress in stdout
+  
+### notes:
+- This script will probably work on Linux, Mac, and Windows, but it has only been tested on Windows.
+- The `-f`/`--folders` flag was tested on PockedBook Touch Lux 4, it does create chapters internally in it's reader
+
+
 
 ## TODO
 - [ ] select input folder
+- [ ] cleanup flag: delete comics afterwards
 - [x] work without range for all in folder
-- [ ] don't flatten flag
-- [ ] progress bar
-- [ ] flag to delete comics afterwards
-- [ ] create my fork
-- [ ] don't rely on windows-specific os stuff like the 1 fork did
-- [ ] after these are done put them into #features or whatever
+- [x] don't flatten flag
+- [x] progress bar
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,43 @@
-# ComicMerge
+# ComicMerge [Fork]
 
 ## Description
 
 This is a simple tool that allows you to merge multiple .cbz files into a single .cbz file.
 
 ## Usage
+```
+usage: python comicmerge_cmd.py [-h] [-v] [-p PREFIX] [-r start end] OUTPUT_FILE
 
-    usage: python comicmerge_cmd.py [-h] [-v] [-p PREFIX] [-r start end] OUTPUT_FILE
-    
-    Merge multiple cbz files into one.
-    
-    positional arguments:
-      OUTPUT_FILE           Name of the .cbz file to be created
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -v, --verbose         More information as to the merging progress
-      -p PREFIX, --prefix PREFIX
-                            Prefix to restrict comics to
-      -r start end, --range start end
-                            Specified by the format X Y. Only the Xth to Yth comic
-                            in the folder will be merged into the output file.
-                            Counting starts at 1. The range is inclusive.
+Merge multiple cbz files into one.
 
-This script will ostensibly work on Linux, Mac, and Windows, but it has only been tested on Windows.
+positional arguments:
+	OUTPUT_FILE           Name of the .cbz file to be created
+
+optional arguments:
+	-h, --help            show this help message and exit
+	-v, --verbose         More information as to the merging progress
+	-p PREFIX, --prefix PREFIX
+						Prefix to restrict comics to
+	-r start end, --range start end
+						Specified by the format X Y. Only the Xth to Yth comic
+						in the folder will be merged into the output file.
+						Counting starts at 1. The range is inclusive.
+```
+
+This script will probably work on Linux, Mac, and Windows, but it has only been tested on Windows.
+
+## Features of this fork
+- also works without providing either range or prefix (merges all comics in folder)
+
+## TODO
+- [ ] select input folder
+- [x] work without range for all in folder
+- [ ] don't flatten flag
+- [ ] progress bar
+- [ ] flag to delete comics afterwards
+- [ ] create my fork
+- [ ] don't rely on windows-specific os stuff like the 1 fork did
+- [ ] after these are done put them into #features or whatever
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ options:
   
 ### notes:
 - This script will probably work on Linux, Mac, and Windows, but it has only been tested on Windows.
-- The `-f`/`--folders` flag was tested on PockedBook Touch Lux 4, it does create chapters internally in it's reader
+- The `-f`/`--folders` flag was tested on PocketBook Touch Lux 4, it does create chapters internally in it's reader.
 
 
 

--- a/comicmerge_cmd.py
+++ b/comicmerge_cmd.py
@@ -5,18 +5,25 @@ from ComicMerge import ComicMerge
 parser = argparse.ArgumentParser(prog='ComicMerge', description='Merge multiple cbz files into one.')
 parser.add_argument('-v', '--verbose', action='store_true', help='More information as to the merging progress')
 parser.add_argument('output_name', metavar='OUTPUT_FILE', type=str,
-                    help='Name of the .cbz file to be created. Will automatically append .cbz if necessary.')
+					help='Name of the .cbz file to be created. Will automatically append .cbz if necessary.')
 parser.add_argument('-p', '--prefix', type=str, help='Prefix to restrict comics to')
 parser.add_argument('-r', '--range', nargs=2, metavar=('start', 'end'), type=int,
-                    help='Specified by the format X Y. Only the Xth to Yth comic in the folder will be merged into the '
-                         'output file.')
+					help='Specified by the format X Y. Only the Xth to Yth comic in the folder will be merged into the '
+						 'output file.')
+# parser.add_argument('-n', '--nested', action='store_true', help='Don\'t flatten the directory tree, ')
 args = parser.parse_args()
 
-if args.prefix is not None:
-    comics_to_merge = ComicMerge.comics_from_prefix(args.prefix)
-elif (len(args.range)) == 0:
-    comics_to_merge = ComicMerge.comics_from_indices(0, -1)
+if args.prefix is not None: # prefix is king
+	comics_to_merge = ComicMerge.comics_from_prefix(args.prefix)
+elif args.range is not None: # fallback to range
+	if (len(args.range)) == 0:
+		comics_to_merge = ComicMerge.comics_from_indices(0, -1)
+	else:
+		comics_to_merge = ComicMerge.comics_from_indices(args.range[0], args.range[1])
+elif args.range is None: # no range = all comics in folder
+	comics_to_merge = ComicMerge.comics_in_folder()
 else:
-    comics_to_merge = ComicMerge.comics_from_indices(args.range[0], args.range[1])
+	raise "ran out of options for comic input: no range, no prefix, no comics in folder apparently."
+	
 comic_merge = ComicMerge(args.output_name, comics_to_merge, args.verbose)
 comic_merge.merge()

--- a/comicmerge_cmd.py
+++ b/comicmerge_cmd.py
@@ -10,7 +10,7 @@ parser.add_argument('-p', '--prefix', type=str, help='Prefix to restrict comics 
 parser.add_argument('-r', '--range', nargs=2, metavar=('start', 'end'), type=int,
 					help='Specified by the format X Y. Only the Xth to Yth comic in the folder will be merged into the '
 						 'output file.')
-# parser.add_argument('-n', '--nested', action='store_true', help='Don\'t flatten the directory tree, ')
+parser.add_argument('-f', '--folders', action='store_true', help='Don\'t flatten the directory tree, keep subfolders')
 args = parser.parse_args()
 
 if args.prefix is not None: # prefix is king
@@ -25,5 +25,5 @@ elif args.range is None: # no range = all comics in folder
 else:
 	raise "ran out of options for comic input: no range, no prefix, no comics in folder apparently."
 	
-comic_merge = ComicMerge(args.output_name, comics_to_merge, args.verbose)
+comic_merge = ComicMerge(args.output_name, comics_to_merge, args.verbose, args.folders)
 comic_merge.merge()


### PR DESCRIPTION
newer ereaders can properly parse subdirectories in cbz, and it creates nice chapters in their reader.
i implemented this for myself, but might aswell open a pr.
tested on a PocketBook touch lux 4 with a 500 page, 26 chapter manga

the readme is currently set up as if it was a fork, so after merging you can modify it, etc.
